### PR TITLE
Modify Rainbow theme

### DIFF
--- a/colors/rainbow-contrast.vim
+++ b/colors/rainbow-contrast.vim
@@ -29,15 +29,22 @@ let g:colors_name = "rainbow-contrast"
 "# Base Colors.                         #
 "########################################
 
-hi  Normal        guifg=#eeeff0  guibg=#1c1f22  gui=NONE
+hi  Normal        guifg=#c7d0d9  guibg=#1c1f22  gui=NONE
 hi  Cursor        guifg=#16181a  guibg=#f8f8f0  gui=NONE
 hi  Visual        guifg=#ffffff  guibg=#b3cc57  gui=NONE
 hi  CursorLine    guifg=NONE     guibg=#1d2022  gui=NONE
 hi  CursorLineNr  guifg=#5c646d  guibg=#060607  gui=NONE
 hi  CursorColumn  guifg=NONE     guibg=#060607  gui=NONE
 hi  ColorColumn   guifg=NONE     guibg=#000000  gui=NONE
-hi  LineNr        guifg=#2d3136  guibg=#0a0b0c  gui=NONE
+
 hi  VertSplit     guifg=#2d3136  guibg=#2d3136  gui=NONE
+hi  LineNr        guifg=#4e555e  guibg=#0a0b0c  gui=NONE
+
+" Applied in ~/.vimrc
+" hi  GitGutterAddDefault    guifg=#a7da1e guibg=#0a0b0c
+" hi  GitGutterChangeDefault guifg=#f7b83d guibg=#0a0b0c
+" hi  GitGutterDeleteDefault guifg=#e61f44 guibg=#0a0b0c
+" hi  SignColumn             guibg=#0a0b0c
 
 hi  StatusLine    guifg=#c7d0d9  guibg=#0a0b0c  gui=bold
 hi  StatusLineNC  guifg=#c7d0d9  guibg=#0a0b0c  gui=NONE
@@ -52,7 +59,7 @@ hi  Directory     guifg=#b3cc57  guibg=NONE     gui=NONE
 
 hi  Comment       guifg=#424c55  guibg=NONE     gui=NONE
 hi  PreProc       guifg=#637280  guibg=NONE     gui=NONE
-hi  Todo          guifg=#637280  guibg=NONE     gui=inverse,bold
+hi  Todo          guifg=#f86f50  guibg=NONE     gui=NONE
 
 hi  DiffAdd       guifg=#393e43  guibg=#a7da1e  gui=bold
 hi  DiffDelete    guifg=#393e43  guibg=#e61f44  gui=NONE
@@ -65,21 +72,23 @@ hi  WarningMsg    guifg=#393e43  guibg=#f7b83d  gui=NONE
 hi  Include       guifg=#b3cc57  guibg=NONE     gui=NONE
 hi  Structure     guifg=#b3cc57  guibg=NONE     gui=NONE
 hi  Define        guifg=#b3cc57  guibg=NONE     gui=NONE
-hi  Function      guifg=#b3cc57  guibg=NONE     gui=NONE
 hi  Keyword       guifg=#b3cc57  guibg=NONE     gui=NONE
 hi  Label         guifg=#c78feb  guibg=NONE     gui=NONE
 hi  Conditional   guifg=#3fb4c5  guibg=NONE     gui=NONE
 hi  Statement     guifg=#3fb4c5  guibg=NONE     gui=NONE
+hi  Function      guifg=#ffbe40  guibg=NONE     gui=NONE
 
 hi  Constant      guifg=NONE     guibg=NONE     gui=NONE
 hi  Identifier    guifg=#f4f7fa  guibg=NONE     gui=NONE
 hi  NonText       guifg=#566a7e  guibg=#111314  gui=NONE
 
-hi  Operator      guifg=#c7d0d9  guibg=NONE     gui=NONE
+" hi Noise  guifg=#3fb4c5 guibg=NONE gui=NONE
+hi  Operator      guifg=#3fb4c5  guibg=NONE     gui=NONE
 hi  Special       guifg=#c7d0d9  guibg=NONE     gui=NONE
 hi  SpecialKey    guifg=#c7d0d9  guibg=#b3cc57  gui=NONE
 hi  StorageClass  guifg=#ef746f  guibg=NONE     gui=NONE
 
+hi  Type          guifg=#ef746f  guibg=NONE     gui=NONE
 hi  Boolean       guifg=#ffbe40  guibg=NONE     gui=NONE
 hi  Float         guifg=#c78feb  guibg=NONE     gui=NONE
 hi  Number        guifg=#c78feb  guibg=NONE     gui=NONE
@@ -89,20 +98,32 @@ hi  Character     guifg=#c78feb  guibg=NONE     gui=NONE
 hi  Tag           guifg=#b3cc57  guibg=NONE     gui=NONE
 hi  Title         guifg=#b3cc57  guibg=NONE     gui=bold
 
-hi  Type          guifg=NONE     guibg=NONE     gui=NONE
 hi  Underlined    guifg=NONE     guibg=NONE     gui=underline
 
 "########################################
 "# Language Overrides                   #
 "########################################
 
-hi  phpIdentifier  guifg=#f4f7fa
-hi  phpMethodsVar  guifg=#c6cacf
-hi  xmlTag         guifg=#b3cc57  guibg=NONE  gui=NONE
-hi  xmlTagName     guifg=#b3cc57  guibg=NONE  gui=NONE
-hi  xmlEndTag      guifg=#b3cc57  guibg=NONE  gui=NONE
+hi  phpIdentifier          guifg=#f4f7fa
+hi  phpMethodsVar          guifg=#c6cacf
+hi  xmlTag                 guifg=#b3cc57         guibg=NONE     gui=NONE
+hi  xmlTagName             guifg=#b3cc57         guibg=NONE     gui=NONE
+hi  xmlEndTag              guifg=#b3cc57         guibg=NONE     gui=NONE
 
-"########################################
-"# Light Theme Overrides                #
-"########################################
+hi  jsClassDefinition      guifg=NONE            guibg=NONE     gui=NONE
+hi  jsThis                 guifg=#c78feb         guibg=NONE     gui=italic
+hi  jsObject               guifg=#b3cc57         guibg=NONE     gui=NONE
+"hi                     jsVariableDef         guifg=#b3cc57  guibg=NONE  gui=NONE
+hi  jsDestructuringBraces  guifg=#3fb4c5         guibg=NONE     gui=NONE
 
+hi  link                   jsBraces              jsNoise
+hi  link                   jsNoise               Noise
+hi  link                   jsDestructuringBlock  jsObjectKey
+hi  link                   jsFlowObjectKey       jsObject
+hi  link                   jsObjectKey           jsObject
+hi  link                   jsObjectProp          jsObject
+hi  link                   jsFuncName            Function
+hi  link                   jsFuncCall            Function
+hi  link                   jsFlowTypeValue       Type
+
+hi pythonAttribute guifg=#b3cc57 guibg=NONE gui=NONE

--- a/colors/rainbow-contrast.vim
+++ b/colors/rainbow-contrast.vim
@@ -37,7 +37,7 @@ hi  CursorLineNr  guifg=#5c646d  guibg=#060607  gui=NONE
 hi  CursorColumn  guifg=NONE     guibg=#060607  gui=NONE
 hi  ColorColumn   guifg=NONE     guibg=#000000  gui=NONE
 
-hi  VertSplit     guifg=#2d3136  guibg=#2d3136  gui=NONE
+hi  VertSplit     guifg=#424c55  guibg=NONE     gui=NONE
 hi  LineNr        guifg=#4e555e  guibg=#0a0b0c  gui=NONE
 
 hi  StatusLine    guifg=#c7d0d9  guibg=#0a0b0c  gui=bold

--- a/colors/rainbow-contrast.vim
+++ b/colors/rainbow-contrast.vim
@@ -80,7 +80,7 @@ hi  Function      guifg=#ffbe40  guibg=NONE     gui=NONE
 
 hi  Constant      guifg=NONE     guibg=NONE     gui=NONE
 hi  Identifier    guifg=#f4f7fa  guibg=NONE     gui=NONE
-hi  NonText       guifg=#566a7e  guibg=#111314  gui=NONE
+hi  NonText       guifg=#566a7e  guibg=NONE     gui=NONE
 
 " hi Noise  guifg=#3fb4c5 guibg=NONE gui=NONE
 hi  Operator      guifg=#3fb4c5  guibg=NONE     gui=NONE

--- a/colors/rainbow-contrast.vim
+++ b/colors/rainbow-contrast.vim
@@ -22,10 +22,14 @@ endif
 
 let g:colors_name = "rainbow-contrast"
 
+" #eeeff0 white
+" #1c1f22 background
+
 "########################################
 "# Base Colors.                         #
 "########################################
 
+hi  Normal        guifg=#eeeff0  guibg=#1c1f22  gui=NONE
 hi  Cursor        guifg=#16181a  guibg=#f8f8f0  gui=NONE
 hi  Visual        guifg=#ffffff  guibg=#b3cc57  gui=NONE
 hi  CursorLine    guifg=NONE     guibg=#1d2022  gui=NONE
@@ -34,45 +38,57 @@ hi  CursorColumn  guifg=NONE     guibg=#060607  gui=NONE
 hi  ColorColumn   guifg=NONE     guibg=#000000  gui=NONE
 hi  LineNr        guifg=#2d3136  guibg=#0a0b0c  gui=NONE
 hi  VertSplit     guifg=#2d3136  guibg=#2d3136  gui=NONE
-hi  MatchParen    guifg=#ef746f  guibg=NONE     gui=underline
+
 hi  StatusLine    guifg=#c7d0d9  guibg=#0a0b0c  gui=bold
 hi  StatusLineNC  guifg=#c7d0d9  guibg=#0a0b0c  gui=NONE
 hi  Pmenu         guifg=#c7d0d9  guibg=#0a0b0c  gui=NONE
 hi  PmenuSel      guifg=NONE     guibg=#b3cc57  gui=NONE
+
 hi  IncSearch     guifg=#c7d0d9  guibg=#c78feb  gui=NONE
 hi  Search        guifg=NONE     guibg=NONE     gui=underline
-hi  Directory     guifg=#b3cc57  guibg=NONE     gui=NONE
+hi  MatchParen    guifg=#ef746f  guibg=NONE     gui=underline
 hi  Folded        guifg=#b8c3cf  guibg=#000000  gui=NONE
-hi  Normal        guifg=#ffbe40  guibg=#16181a  gui=NONE
-hi  Boolean       guifg=#ffbe40  guibg=NONE     gui=NONE
-hi  Character     guifg=#c78feb  guibg=NONE     gui=NONE
+hi  Directory     guifg=#b3cc57  guibg=NONE     gui=NONE
+
 hi  Comment       guifg=#424c55  guibg=NONE     gui=NONE
-hi  Conditional   guifg=#3fb4c5  guibg=NONE     gui=NONE
-hi  Constant      guifg=NONE     guibg=NONE     gui=NONE
-hi  Define        guifg=#b3cc57  guibg=NONE     gui=NONE
+hi  PreProc       guifg=#637280  guibg=NONE     gui=NONE
+hi  Todo          guifg=#637280  guibg=NONE     gui=inverse,bold
+
 hi  DiffAdd       guifg=#393e43  guibg=#a7da1e  gui=bold
 hi  DiffDelete    guifg=#393e43  guibg=#e61f44  gui=NONE
 hi  DiffChange    guifg=#393e43  guibg=#f7b83d  gui=NONE
 hi  DiffText      guifg=#393e43  guibg=#f7b83d  gui=bold
+
 hi  ErrorMsg      guifg=#393e43  guibg=#e61f44  gui=NONE
 hi  WarningMsg    guifg=#393e43  guibg=#f7b83d  gui=NONE
-hi  Float         guifg=#c78feb  guibg=NONE     gui=NONE
+
+hi  Include       guifg=#b3cc57  guibg=NONE     gui=NONE
+hi  Structure     guifg=#b3cc57  guibg=NONE     gui=NONE
+hi  Define        guifg=#b3cc57  guibg=NONE     gui=NONE
 hi  Function      guifg=#b3cc57  guibg=NONE     gui=NONE
-hi  Identifier    guifg=#f4f7fa  guibg=NONE     gui=NONE
 hi  Keyword       guifg=#b3cc57  guibg=NONE     gui=NONE
 hi  Label         guifg=#c78feb  guibg=NONE     gui=NONE
+hi  Conditional   guifg=#3fb4c5  guibg=NONE     gui=NONE
+hi  Statement     guifg=#3fb4c5  guibg=NONE     gui=NONE
+
+hi  Constant      guifg=NONE     guibg=NONE     gui=NONE
+hi  Identifier    guifg=#f4f7fa  guibg=NONE     gui=NONE
 hi  NonText       guifg=#566a7e  guibg=#111314  gui=NONE
-hi  Number        guifg=#c78feb  guibg=NONE     gui=NONE
+
 hi  Operator      guifg=#c7d0d9  guibg=NONE     gui=NONE
-hi  PreProc       guifg=#637280  guibg=NONE     gui=NONE
 hi  Special       guifg=#c7d0d9  guibg=NONE     gui=NONE
 hi  SpecialKey    guifg=#c7d0d9  guibg=#b3cc57  gui=NONE
-hi  Statement     guifg=#3fb4c5  guibg=NONE     gui=NONE
 hi  StorageClass  guifg=#ef746f  guibg=NONE     gui=NONE
+
+hi  Boolean       guifg=#ffbe40  guibg=NONE     gui=NONE
+hi  Float         guifg=#c78feb  guibg=NONE     gui=NONE
+hi  Number        guifg=#c78feb  guibg=NONE     gui=NONE
 hi  String        guifg=#c78feb  guibg=NONE     gui=NONE
+hi  Character     guifg=#c78feb  guibg=NONE     gui=NONE
+
 hi  Tag           guifg=#b3cc57  guibg=NONE     gui=NONE
 hi  Title         guifg=#b3cc57  guibg=NONE     gui=bold
-hi  Todo          guifg=#637280  guibg=NONE     gui=inverse,bold
+
 hi  Type          guifg=NONE     guibg=NONE     gui=NONE
 hi  Underlined    guifg=NONE     guibg=NONE     gui=underline
 

--- a/colors/rainbow-contrast.vim
+++ b/colors/rainbow-contrast.vim
@@ -123,6 +123,8 @@ hi  link                   jsFlowTypeValue       Type
 
 hi pythonAttribute guifg=#b3cc57 guibg=NONE gui=NONE
 
+hi  rustSelf               guifg=#c78feb         guibg=NONE     gui=italic
+
 "########################################
 "# Plugins                              #
 "########################################

--- a/colors/rainbow-contrast.vim
+++ b/colors/rainbow-contrast.vim
@@ -40,12 +40,6 @@ hi  ColorColumn   guifg=NONE     guibg=#000000  gui=NONE
 hi  VertSplit     guifg=#2d3136  guibg=#2d3136  gui=NONE
 hi  LineNr        guifg=#4e555e  guibg=#0a0b0c  gui=NONE
 
-" Applied in ~/.vimrc
-" hi  GitGutterAddDefault    guifg=#a7da1e guibg=#0a0b0c
-" hi  GitGutterChangeDefault guifg=#f7b83d guibg=#0a0b0c
-" hi  GitGutterDeleteDefault guifg=#e61f44 guibg=#0a0b0c
-" hi  SignColumn             guibg=#0a0b0c
-
 hi  StatusLine    guifg=#c7d0d9  guibg=#0a0b0c  gui=bold
 hi  StatusLineNC  guifg=#c7d0d9  guibg=#0a0b0c  gui=NONE
 hi  Pmenu         guifg=#c7d0d9  guibg=#0a0b0c  gui=NONE
@@ -113,9 +107,10 @@ hi  xmlEndTag              guifg=#b3cc57         guibg=NONE     gui=NONE
 hi  jsClassDefinition      guifg=NONE            guibg=NONE     gui=NONE
 hi  jsThis                 guifg=#c78feb         guibg=NONE     gui=italic
 hi  jsObject               guifg=#b3cc57         guibg=NONE     gui=NONE
-"hi                     jsVariableDef         guifg=#b3cc57  guibg=NONE  gui=NONE
 hi  jsDestructuringBraces  guifg=#3fb4c5         guibg=NONE     gui=NONE
 
+hi  link                   jsModuleKeyword       Identifier
+hi  link                   jsVariableDef         Identifier
 hi  link                   jsBraces              jsNoise
 hi  link                   jsNoise               Noise
 hi  link                   jsDestructuringBlock  jsObjectKey
@@ -127,3 +122,16 @@ hi  link                   jsFuncCall            Function
 hi  link                   jsFlowTypeValue       Type
 
 hi pythonAttribute guifg=#b3cc57 guibg=NONE gui=NONE
+
+"########################################
+"# Plugins                              #
+"########################################
+
+" Applied in ~/.vimrc
+hi  GitGutterAddDefault    guifg=#a7da1e guibg=#0a0b0c
+hi  GitGutterChangeDefault guifg=#f7b83d guibg=#0a0b0c
+hi  GitGutterDeleteDefault guifg=#e61f44 guibg=#0a0b0c
+hi  SignColumn             guibg=#0a0b0c
+
+hi NERDTreeFile guifg=#b8c3cf
+hi NERDTreeDir guifg=#ef746f

--- a/colors/rainbow-contrast.vim
+++ b/colors/rainbow-contrast.vim
@@ -26,65 +26,65 @@ let g:colors_name = "rainbow-contrast"
 "# Base Colors.                         #
 "########################################
 
-hi Cursor         guifg=#16181a guibg=#f8f8f0 gui=NONE
-hi Visual         guifg=#ffffff guibg=#b3cc57 gui=NONE
-hi CursorLine     guifg=NONE guibg=#1d2022 gui=NONE
-hi CursorLineNr   guifg=#5c646d guibg=#060607 gui=NONE
-hi CursorColumn   guifg=NONE guibg=#060607 gui=NONE
-hi ColorColumn    guifg=NONE guibg=#000000 gui=NONE
-hi LineNr         guifg=#2d3136 guibg=#0a0b0c gui=NONE
-hi VertSplit      guifg=#2d3136 guibg=#2d3136 gui=NONE
-hi MatchParen     guifg=#ef746f guibg=NONE gui=underline
-hi StatusLine     guifg=#c7d0d9 guibg=#0a0b0c gui=bold
-hi StatusLineNC   guifg=#c7d0d9 guibg=#0a0b0c gui=NONE
-hi Pmenu          guifg=#c7d0d9 guibg=#0a0b0c gui=NONE
-hi PmenuSel       guifg=NONE guibg=#b3cc57 gui=NONE
-hi IncSearch      guifg=#c7d0d9 guibg=#c78feb gui=NONE
-hi Search         guifg=NONE guibg=NONE gui=underline
-hi Directory      guifg=#b3cc57 guibg=NONE gui=NONE
-hi Folded         guifg=#b8c3cf guibg=#000000 gui=NONE
-hi Normal         guifg=#ffbe40 guibg=#16181a gui=NONE
-hi Boolean        guifg=#ffbe40 guibg=NONE gui=NONE
-hi Character      guifg=#c78feb guibg=NONE gui=NONE
-hi Comment        guifg=#424c55 guibg=NONE gui=NONE
-hi Conditional    guifg=#3fb4c5 guibg=NONE gui=NONE
-hi Constant       guifg=NONE guibg=NONE gui=NONE
-hi Define         guifg=#b3cc57 guibg=NONE gui=NONE
-hi DiffAdd        guifg=#393e43 guibg=#a7da1e gui=bold
-hi DiffDelete     guifg=#393e43 guibg=#e61f44 gui=NONE
-hi DiffChange     guifg=#393e43 guibg=#f7b83d gui=NONE
-hi DiffText       guifg=#393e43 guibg=#f7b83d gui=bold
-hi ErrorMsg       guifg=#393e43 guibg=#e61f44 gui=NONE
-hi WarningMsg     guifg=#393e43 guibg=#f7b83d gui=NONE
-hi Float          guifg=#c78feb guibg=NONE gui=NONE
-hi Function       guifg=#b3cc57 guibg=NONE gui=NONE
-hi Identifier     guifg=#f4f7fa guibg=NONE gui=NONE
-hi Keyword        guifg=#b3cc57 guibg=NONE gui=NONE
-hi Label          guifg=#c78feb guibg=NONE gui=NONE
-hi NonText        guifg=#566a7e guibg=#111314 gui=NONE
-hi Number         guifg=#c78feb guibg=NONE gui=NONE
-hi Operator       guifg=#c7d0d9 guibg=NONE gui=NONE
-hi PreProc        guifg=#637280 guibg=NONE gui=NONE
-hi Special        guifg=#c7d0d9 guibg=NONE gui=NONE
-hi SpecialKey     guifg=#c7d0d9 guibg=#b3cc57 gui=NONE
-hi Statement      guifg=#3fb4c5 guibg=NONE gui=NONE
-hi StorageClass   guifg=#ef746f guibg=NONE gui=NONE
-hi String         guifg=#c78feb guibg=NONE gui=NONE
-hi Tag            guifg=#b3cc57 guibg=NONE gui=NONE
-hi Title          guifg=#b3cc57 guibg=NONE gui=bold
-hi Todo           guifg=#637280 guibg=NONE gui=inverse,bold
-hi Type           guifg=NONE guibg=NONE gui=NONE
-hi Underlined     guifg=NONE guibg=NONE gui=underline
+hi  Cursor        guifg=#16181a  guibg=#f8f8f0  gui=NONE
+hi  Visual        guifg=#ffffff  guibg=#b3cc57  gui=NONE
+hi  CursorLine    guifg=NONE     guibg=#1d2022  gui=NONE
+hi  CursorLineNr  guifg=#5c646d  guibg=#060607  gui=NONE
+hi  CursorColumn  guifg=NONE     guibg=#060607  gui=NONE
+hi  ColorColumn   guifg=NONE     guibg=#000000  gui=NONE
+hi  LineNr        guifg=#2d3136  guibg=#0a0b0c  gui=NONE
+hi  VertSplit     guifg=#2d3136  guibg=#2d3136  gui=NONE
+hi  MatchParen    guifg=#ef746f  guibg=NONE     gui=underline
+hi  StatusLine    guifg=#c7d0d9  guibg=#0a0b0c  gui=bold
+hi  StatusLineNC  guifg=#c7d0d9  guibg=#0a0b0c  gui=NONE
+hi  Pmenu         guifg=#c7d0d9  guibg=#0a0b0c  gui=NONE
+hi  PmenuSel      guifg=NONE     guibg=#b3cc57  gui=NONE
+hi  IncSearch     guifg=#c7d0d9  guibg=#c78feb  gui=NONE
+hi  Search        guifg=NONE     guibg=NONE     gui=underline
+hi  Directory     guifg=#b3cc57  guibg=NONE     gui=NONE
+hi  Folded        guifg=#b8c3cf  guibg=#000000  gui=NONE
+hi  Normal        guifg=#ffbe40  guibg=#16181a  gui=NONE
+hi  Boolean       guifg=#ffbe40  guibg=NONE     gui=NONE
+hi  Character     guifg=#c78feb  guibg=NONE     gui=NONE
+hi  Comment       guifg=#424c55  guibg=NONE     gui=NONE
+hi  Conditional   guifg=#3fb4c5  guibg=NONE     gui=NONE
+hi  Constant      guifg=NONE     guibg=NONE     gui=NONE
+hi  Define        guifg=#b3cc57  guibg=NONE     gui=NONE
+hi  DiffAdd       guifg=#393e43  guibg=#a7da1e  gui=bold
+hi  DiffDelete    guifg=#393e43  guibg=#e61f44  gui=NONE
+hi  DiffChange    guifg=#393e43  guibg=#f7b83d  gui=NONE
+hi  DiffText      guifg=#393e43  guibg=#f7b83d  gui=bold
+hi  ErrorMsg      guifg=#393e43  guibg=#e61f44  gui=NONE
+hi  WarningMsg    guifg=#393e43  guibg=#f7b83d  gui=NONE
+hi  Float         guifg=#c78feb  guibg=NONE     gui=NONE
+hi  Function      guifg=#b3cc57  guibg=NONE     gui=NONE
+hi  Identifier    guifg=#f4f7fa  guibg=NONE     gui=NONE
+hi  Keyword       guifg=#b3cc57  guibg=NONE     gui=NONE
+hi  Label         guifg=#c78feb  guibg=NONE     gui=NONE
+hi  NonText       guifg=#566a7e  guibg=#111314  gui=NONE
+hi  Number        guifg=#c78feb  guibg=NONE     gui=NONE
+hi  Operator      guifg=#c7d0d9  guibg=NONE     gui=NONE
+hi  PreProc       guifg=#637280  guibg=NONE     gui=NONE
+hi  Special       guifg=#c7d0d9  guibg=NONE     gui=NONE
+hi  SpecialKey    guifg=#c7d0d9  guibg=#b3cc57  gui=NONE
+hi  Statement     guifg=#3fb4c5  guibg=NONE     gui=NONE
+hi  StorageClass  guifg=#ef746f  guibg=NONE     gui=NONE
+hi  String        guifg=#c78feb  guibg=NONE     gui=NONE
+hi  Tag           guifg=#b3cc57  guibg=NONE     gui=NONE
+hi  Title         guifg=#b3cc57  guibg=NONE     gui=bold
+hi  Todo          guifg=#637280  guibg=NONE     gui=inverse,bold
+hi  Type          guifg=NONE     guibg=NONE     gui=NONE
+hi  Underlined    guifg=NONE     guibg=NONE     gui=underline
 
 "########################################
 "# Language Overrides                   #
 "########################################
 
-hi phpIdentifier     guifg=#f4f7fa
-hi phpMethodsVar     guifg=#c6cacf
-hi xmlTag            guifg=#b3cc57 guibg=NONE gui=NONE
-hi xmlTagName        guifg=#b3cc57 guibg=NONE gui=NONE
-hi xmlEndTag         guifg=#b3cc57 guibg=NONE gui=NONE
+hi  phpIdentifier  guifg=#f4f7fa
+hi  phpMethodsVar  guifg=#c6cacf
+hi  xmlTag         guifg=#b3cc57  guibg=NONE  gui=NONE
+hi  xmlTagName     guifg=#b3cc57  guibg=NONE  gui=NONE
+hi  xmlEndTag      guifg=#b3cc57  guibg=NONE  gui=NONE
 
 "########################################
 "# Light Theme Overrides                #

--- a/colors/rainbow.vim
+++ b/colors/rainbow.vim
@@ -43,7 +43,7 @@ hi IncSearch      guifg=#c7d0d9 guibg=#c78feb gui=NONE
 hi Search         guifg=NONE guibg=NONE gui=underline
 hi Directory      guifg=#b3cc57 guibg=NONE gui=NONE
 hi Folded         guifg=#b8c3cf guibg=#202326 gui=NONE
-hi Normal         guifg=#ffbe40 guibg=#373c42 gui=NONE
+hi Normal         guifg=#eeeff0 guibg=#373c42 gui=NONE
 hi Boolean        guifg=#ffbe40 guibg=NONE gui=NONE
 hi Character      guifg=#c78feb guibg=NONE gui=NONE
 hi Comment        guifg=#657482 guibg=NONE gui=NONE
@@ -90,3 +90,13 @@ hi xmlEndTag         guifg=#b3cc57 guibg=NONE gui=NONE
 "# Light Theme Overrides                #
 "########################################
 
+"########################################
+"# Indent plugin                        #
+"########################################
+
+hi IndentLine        guifg=#b8c3cf guibg=#373c42
+
+hi GitGutterAddDefault      guifg=#a7da1e guibg=#2b2f34
+hi GitGutterChangeDefault   guifg=#ffbe40 guibg=#2b2f34
+hi GitGutterDeleteDefault   guifg=#e61f44 guibg=#2b2f34
+hi SignColumn               guibg=#2b2f34


### PR DESCRIPTION
This modification updates the Rainbow theme highlighting to match the example in the [theme previewer](https://rainglow.io/preview/#rainbow). Most notably, the "normal" font color is neutral off-white, not the theme's yellow color.